### PR TITLE
Fix sed pattern to match gevent/greenlet lines across Odoo versions

### DIFF
--- a/16_Dockerfile
+++ b/16_Dockerfile
@@ -44,7 +44,7 @@ COPY 16_requirements.txt /tmp/extra_requirements.txt
 RUN python3 -m pip install --upgrade pip \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
     # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
-    && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" requirements.txt \
+    && sed -i -E "s/gevent==21\.8\.0(.*)/gevent==22.10.2\1/;s/greenlet==1\.1\.2(.*)/greenlet==2.0.2\1/" requirements.txt \
     && pip install -r requirements.txt \
     && pip install -r /tmp/extra_requirements.txt \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOPDF_VERSION}-3/wkhtmltox_${WKHTMLTOPDF_VERSION}-3.bookworm_amd64.deb \

--- a/18_Dockerfile
+++ b/18_Dockerfile
@@ -44,7 +44,7 @@ COPY 18_requirements.txt /tmp/extra_requirements.txt
 RUN python3 -m pip install --upgrade pip \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
     # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
-    && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" requirements.txt \
+    && sed -i -E "s/gevent==21\.8\.0(.*)/gevent==22.10.2\1/;s/greenlet==1\.1\.2(.*)/greenlet==2.0.2\1/" requirements.txt \
     && pip install -r requirements.txt \
     && pip install -r /tmp/extra_requirements.txt \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOPDF_VERSION}-3/wkhtmltox_${WKHTMLTOPDF_VERSION}-3.bookworm_amd64.deb \


### PR DESCRIPTION
The sed regex for patching gevent/greenlet versions expected `python_version == '3.10'` (18.0 format) but the 16.0 requirements.txt uses `python_version > '3.9' and python_version <= '3.10'`. Broadened the pattern to match any trailing environment markers.