### PR TITLE
Add cloc to Dockerfiles

### DIFF
--- a/16_Dockerfile
+++ b/16_Dockerfile
@@ -12,6 +12,7 @@ ENV LANG C.UTF-8
 RUN set -x; \
     apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
+        cloc \
         curl \
         git
 

--- a/18_Dockerfile
+++ b/18_Dockerfile
@@ -12,6 +12,7 @@ ENV LANG C.UTF-8
 RUN set -x; \
     apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
+        cloc \
         curl \
         git
 


### PR DESCRIPTION
Install cloc (Count Lines of Code) in both 16_Dockerfile and 18_Dockerfile.

Perl is already present in the base image, so this only pulls in ~1.2 MB of small Perl library dependencies.